### PR TITLE
fix a minor but realpath related

### DIFF
--- a/bin/pear-package.php
+++ b/bin/pear-package.php
@@ -14,7 +14,7 @@ if (!file_exists($package_xml_file)) {
 
 $package_data               = simplexml_load_file($package_xml_file);
 $dir_name                   = (string) $package_data->contents->dir['name'];
-$target                     = realpath("../$dir_name");
+$target                     = dirname(__DIR__);
 $base_install_dir           = (string) $package_data->contents->dir['baseinstalldir'];
 unset($package_data->contents->dir);
 $main_dir                   = $package_data->contents->addChild('dir');


### PR DESCRIPTION
the Realpath has different behavior dependent of O.S and php Version.
change it to use constant dirname(_ _ DIR _ _); 
into pear-package.php
