### PR TITLE
Add phpunit as a development dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,8 @@
         "psr-0": {
             "Respect\\Foundation": "src\/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
     }
 }


### PR DESCRIPTION
So executing `composer.phar install --dev` will install phpunit.

To execute the test suite just run:

```
$ vendor/bin/phpunit test/
```
